### PR TITLE
refactor: remove port binding to localhost for database services

### DIFF
--- a/compose/mariadb.yml
+++ b/compose/mariadb.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: "2.2"
 
 services:
   mariadb:
@@ -7,8 +7,6 @@ services:
     mem_limit: ${MYSQL_MEMORY_LIMIT:-1G}
     volumes:
       - ${PATH_DATA:-./data}/mariadb:/var/lib/mysql
-    ports:
-      - ${DB_PORT:-3306}:3306
     environment:
       MYSQL_DATABASE: ${DB_DATABASE}
       MYSQL_USER: ${DB_USERNAME}

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: "2.2"
 
 services:
   mysql:
@@ -8,8 +8,6 @@ services:
     mem_limit: ${MYSQL_MEMORY_LIMIT:-1G}
     volumes:
       - ${PATH_DATA:-./data}/mysql:/var/lib/mysql
-    ports:
-      - ${DB_PORT:-3306}:3306
     environment:
       MYSQL_DATABASE: ${DB_DATABASE}
       MYSQL_USER: ${DB_USERNAME}

--- a/compose/postgres.yml
+++ b/compose/postgres.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: "2.2"
 
 services:
   postgres:
@@ -7,8 +7,6 @@ services:
     mem_limit: ${POSTGRES_MEMORY_LIMIT:-1G}
     volumes:
       - ${PATH_DATA:-./data}/postgres:/var/lib/postgresql/data
-    ports:
-      - ${DB_PORT:-5432}:5432
     environment:
       POSTGRES_DB: ${DB_DATABASE}
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION
The database services: MySQL, Postgres, MariaDB are binding port to localhost unnecessary. Please define port binding in `docker-compose.override.yml` instead.