### PR TITLE
feat!: traefik will be compatible with multi-projects

### DIFF
--- a/compose/laravel/echo-server.yml
+++ b/compose/laravel/echo-server.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   laravel-echo-server:
@@ -7,8 +12,11 @@ services:
     labels:
       - traefik.enable=true
       - traefik.port=6001
-      - traefik.http.routers.laravel-echo.rule=Host(`${DOMAIN}`) && PathPrefix(`/socket.io`)
-      - traefik.http.services.laravel-echo.loadbalancer.server.port=6001
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-laravel-echo.rule=Host(`${DOMAIN}`) && PathPrefix(`/socket.io`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-laravel-echo.loadbalancer.server.port=6001
+    networks:
+      - default
+      - frontend
     environment:
       - REDIS_HOST=redis
       - REDIS_KEY_PREFIX=${LARAVEL_ECHO_SERVER_REDIS_KEY_PREFIX}

--- a/compose/mailhog.yml
+++ b/compose/mailhog.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   mailhog:
@@ -6,8 +11,11 @@ services:
     restart: always
     labels:
       - traefik.enable=true
-      - traefik.http.routers.mailhog.rule=Host(`${DOMAIN_SECONDARY}`)
-      - traefik.http.services.mailhog.loadbalancer.server.port=8025
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-mailhog.rule=Host(`${DOMAIN_SECONDARY}`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-mailhog.loadbalancer.server.port=8025
+    networks:
+      - default
+      - frontend
     mem_limit: ${MEMORY_LIMIT_MAILHOG:-200m}
     environment:
       - MH_STORAGE=maildir

--- a/compose/minio.yml
+++ b/compose/minio.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   minio:
@@ -9,8 +14,11 @@ services:
       - /data
     labels:
       - traefik.enable=true
-      - traefik.http.routers.minio.rule=Host(`minio.${DOMAIN_SECONDARY}`)
-      - traefik.http.services.minio.loadbalancer.server.port=9000
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-minio.rule=Host(`minio.${DOMAIN_SECONDARY}`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-minio.loadbalancer.server.port=9000
+    networks:
+      - default
+      - frontend
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minio}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-miniostorage}

--- a/compose/pgadmin.yml
+++ b/compose/pgadmin.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   pgadmin:
@@ -6,10 +11,13 @@ services:
     restart: always
     labels:
       - traefik.enable=true
-      - traefik.http.routers.pgadmin.rule=Host(`pgadmin.${DOMAIN_SECONDARY}`)
-      - traefik.http.services.pgadmin.loadbalancer.server.port=80
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-pgadmin.rule=Host(`pgadmin.${DOMAIN_SECONDARY}`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-pgadmin.loadbalancer.server.port=80
+    networks:
+      - default
+      - frontend
     environment:
-      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:-admin}       # Cannot be changed after first launch
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:-admin} # Cannot be changed after first launch
       - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD:-admin} # Cannot be changed after first launch
     volumes:
-      - ${PATH_DATA:-./data}/pgadmin:/var/lib/pgadmin               # Delete data files to start again with new user
+      - ${PATH_DATA:-./data}/pgadmin:/var/lib/pgadmin # Delete data files to start again with new user

--- a/compose/php.yml
+++ b/compose/php.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   nginx:
@@ -10,8 +15,11 @@ services:
       - envsubst '$${DOCUMENT_ROOT}' < /etc/nginx/conf.d/default.conf.tpl | tee /etc/nginx/conf.d/default.conf && exec nginx -g "daemon off;"
     labels:
       - traefik.enable=true
-      - traefik.http.routers.nginx.rule=Host(`${DOMAIN}`)
-      - traefik.http.services.nginx.loadbalancer.server.port=80
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-nginx.rule=Host(`${DOMAIN}`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-nginx.loadbalancer.server.port=80
+    networks:
+      - default
+      - frontend
     environment:
       - DOCUMENT_ROOT=${NGINX_DOCUMENT_ROOT:-/php/public}
     volumes:

--- a/compose/phpmyadmin.yml
+++ b/compose/phpmyadmin.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   phpmyadmin:
@@ -6,8 +11,11 @@ services:
     restart: always
     labels:
       - traefik.enable=true
-      - traefik.http.routers.phpmyadmin.rule=Host(`phpmyadmin.${DOMAIN_SECONDARY}`)
-      - traefik.http.services.phpmyadmin.loadbalancer.server.port=80
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin.rule=Host(`phpmyadmin.${DOMAIN_SECONDARY}`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-phpmyadmin.loadbalancer.server.port=80
+    networks:
+      - default
+      - frontend
     environment:
       - PMA_HOSTS=mysql,mysql-test
       - PMA_PORT=3306

--- a/compose/web.yml
+++ b/compose/web.yml
@@ -1,4 +1,9 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  default:
+  frontend:
+    external: true
 
 services:
   web:
@@ -6,8 +11,11 @@ services:
     restart: always
     labels:
       - traefik.enable=true
-      - traefik.http.routers.web.rule=Host(`${DOMAIN}`)
-      - traefik.http.services.web.loadbalancer.server.port=3000
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-web.rule=Host(`${DOMAIN}`)
+      - traefik.http.services.${COMPOSE_PROJECT_NAME}-web.loadbalancer.server.port=3000
+    networks:
+      - default
+      - frontend
     working_dir: /web
     volumes:
       - ${PATH_WEB}:/web
@@ -16,8 +24,11 @@ services:
 
   nginx:
     labels:
-      - traefik.http.routers.nginx.rule=Host(`${DOMAIN}`) && PathPrefix(`${API_PATH_PREFIX:-/api}`)
+      - traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-api-stripprefix.stripprefix.prefixes=${API_PATH_PREFIX:-/api}
+      - traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-api-stripprefix.stripprefix.forceSlash=false
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-api-pathprefix.rule=Host(`${DOMAIN}`) && PathPrefix(`${API_PATH_PREFIX:-/api}`)
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-api-pathprefix.middlewares=${COMPOSE_PROJECT_NAME}-api-stripprefix@docker
     networks:
       default:
         aliases:
-          - api
+          - ${COMPOSE_PROJECT_NAME}-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
-version: '2.2'
+version: "2.2"
+
+networks:
+  frontend:
+    name: frontend
 
 services:
   traefik:
@@ -8,10 +12,13 @@ services:
       - --api.dashboard=true
       - --entrypoints.http.address=:80
       - --providers.docker
+      - --providers.docker.network=frontend
       - --providers.docker.watch=true
       - --providers.docker.exposedbydefault=false
     ports:
       - ${PORT:-80}:80
+    networks:
+      - frontend
     labels:
       - traefik.enable=true
       - traefik.http.routers.traefik.rule=Host(`traefik.${DOMAIN_SECONDARY}`)


### PR DESCRIPTION
This PR will make Traefik service will be compatible with multi-projects which are using this library.

- Separate the Traefik network and the default network. Traefik will only work in the 'frontend' network.
- Use COMPOSE_PROJECT_NAME as the prefix when defining Traefik router/service/middleware
- Separate `/api` router from `nginx` router.