### PR TITLE
fix: traefik has been compatible with multi-projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Notable things are:
 
 - `PATH_PHP`, `PATH_WEB`: paths to your code directories. They will be mounted into the containers.
 - `DOMAIN` and `PORT`: Domain and port to access the application.
+- `DOMAIN_WEB`: defines public domain for your Node.js application.
 - `COMPOSE_PROJECT_NAME`: used to isolate environments when you run multiple projects.
+
+*Note:* To use the Node.js application & the PHP application in the same domain
+```shell
+cp docker-compose.override.yml.example docker-compose.override.yml
+```
 
 Not very important things:
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,6 @@
+version: '2.2'
+
+services:
+  nginx:
+    labels:
+      - traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-api-stripprefix.stripprefix.prefixes=${API_PATH_PREFIX:-/}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ services:
       - frontend
     labels:
       - traefik.enable=true
-      - traefik.http.routers.traefik.rule=Host(`traefik.${DOMAIN_SECONDARY}`)
-      - traefik.http.routers.traefik.service=api@internal
-      - traefik.http.middlewares.traefik-dashboard.redirectRegex.regex=/
-      - traefik.http.middlewares.traefik-dashboard.redirectRegex.replacement=/dashboard/
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-traefik.rule=Host(`traefik.${DOMAIN_SECONDARY}`)
+      - traefik.http.routers.${COMPOSE_PROJECT_NAME}-traefik.service=api@internal
+      - traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-traefik-dashboard.redirectRegex.regex=/
+      - traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-traefik-dashboard.redirectRegex.replacement=/dashboard/
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
- Update traefik labels using `COMPOSE_PROJECT_NAME` to separate traefik router 